### PR TITLE
dirinstall on 12.04 appears to require `fai-divert -a /sbin/initctl`

### DIFF
--- a/doc/fai-guide.txt
+++ b/doc/fai-guide.txt
@@ -1208,7 +1208,7 @@ that is used by `debconf-set-selections(8)`.
 
 _package_config/_::
 Files with class names contain lists of software packages to be
-installed or removed. Files named '*.asc' are added to the key list of
+installed or removed. Files named 'class.asc' are added to the key list of
 apt.
 
 _scripts/_::
@@ -1683,13 +1683,13 @@ and don't list them otherwise
 
 
 Before installing packages, FAI will add the content of all files
-named _package_config/*.asc_ to the list of apt keys. If your local
+named _package_config/class.asc_ to the list of apt keys. If your local
 repository is signed by your keyid AB12CD34 you can easily add this key,
 so FAI will use it during installation. Use this command for creating
-the '.asc' file:
+the 'class.asc' file:
 
 ----
-faiserver$ gpg -a --export AB12CD34 > /srv/fai/config/package_config/myrepo.asc
+faiserver$ gpg -a --export AB12CD34 > /srv/fai/config/package_config/myclass.asc
 ----
 
 

--- a/lib/updatebase
+++ b/lib/updatebase
@@ -17,7 +17,7 @@ if [ "$FAI_ACTION" = "install" -o "$FAI_ACTION" = "dirinstall" ]; then
     # then init will eat up much cpu time
     # fake some more programs
     fai-divert -a /sbin/init /usr/sbin/liloconfig /usr/sbin/invoke-rc.d
-    fai-divert -a /usr/sbin/policy-rc.d
+    fai-divert -a /usr/sbin/policy-rc.d /sbin/initctl
     # never start any daemons inside chroot during installtion
     cat > $FAI_ROOT/usr/sbin/policy-rc.d <<EOF
 #!/bin/sh


### PR DESCRIPTION
it appears that upstart in precise behaves differently than lucid with respect to chroots (looks like it started supporting chroot "sessions" in natty). in my testing this caused problems with both lucid and
precise guests. when performing a lucid dirinstall i ended up w/atd and acpid processes running outside the chroot. with a precise dirinstall init complained that it had had its "Configuration directory deleted" (referencing the path to the chroot) and was left in a somewhat confused state, logging errs like:
init: Failed to spawn network-interface (tap0) pre-start process: unable to execute: No such file or directory
on vm bring-up.

cf. https://bugs.launchpad.net/ubuntu/+source/fai/+bug/1021506
